### PR TITLE
Export package as CommonJS when using require

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Pan and zoom a container using React Hooks",
   "source": "src/index.ts",
   "main": "./dist/index.js",
-  "exports": "./dist/index.modern.js",
+  "exports": {
+    "import": "./dist/index.modern.js",
+    "require": "./dist/index.js"
+  },
   "module": "./dist/index.module.js",
   "unpkg": "./dist/index.umd.js",
   "repository": "https://github.com/wouterraateland/use-pan-and-zoom.git",


### PR DESCRIPTION
I would like to start by saying how awesome and easy to use this library is. Saved me ton of time and I had basic editor running in minutes. Great work! 💯 

I stumbled into one package issue when using this with NextJS that has SSR. In node it uses modern package version instead of CommonJS.
<details>
<summary>Error for reference</summary>
<p>

```
Server Error
SyntaxError: Cannot use import statement outside a module

This error happened while generating the page. Any console logs will be displayed in the terminal window.
Call Stack
<unknown>
file:///../node_modules/use-pan-and-zoom/dist/index.modern.js (1)
Object.compileFunction
node:vm (352:18)
wrapSafe
node:internal/modules/cjs/loader (1031:15)
Module._compile
node:internal/modules/cjs/loader (1065:27)
Object.Module._extensions..js
node:internal/modules/cjs/loader (1153:10)
Module.load
node:internal/modules/cjs/loader (981:32)
Function.Module._load
node:internal/modules/cjs/loader (822:12)
Module.require
node:internal/modules/cjs/loader (1005:19)
require
node:internal/modules/cjs/helpers (94:18)
Object.use-pan-and-zoom
file:///../.next/server/pages/index.js (102:18)
__webpack_require__
file:///../.next/server/webpack-runtime.js (33:42)
```

</p>
</details>

As solution I just defined that when using `require` it should also use CommonJS version of the package.