### PR TITLE
fix: added type definition location to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,16 @@
   "description": "Pan and zoom a container using React Hooks",
   "source": "src/index.ts",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.modern.js",
-    "require": "./dist/index.js"
+    "import": {
+      "default": "./dist/index.modern.js",
+      "types": "./dist/index.d.ts"
+    },
+    "require":  {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   },
   "module": "./dist/index.module.js",
   "unpkg": "./dist/index.umd.js",


### PR DESCRIPTION
Hey nice lib.

I have one small fix for something happening on my environment. I'm using Vite+Typescript and it wasn't the type definitions for the package. I've added the type definitions to the package.json exports, which resolves the issue.

![image](https://github.com/wouterraateland/use-pan-and-zoom/assets/3497863/0775394f-0b1d-4fac-99c5-3fc2b8f5f17b)
